### PR TITLE
Add instructions for bundling JS

### DIFF
--- a/docs/setup-android.md
+++ b/docs/setup-android.md
@@ -65,3 +65,26 @@ npm run storybook
 npm run storybook-android
 ```
 And open http://localhost:9001 on a web browser.
+
+## Bundling JS into the storybook app
+
+From above steps you can get a storybook development environment set up. In the development set up the javascript sources are not bundled into the app itself. They are fetched from the packager server running on your computer, allowing you to bring latest changes into the app by reloading JS.
+
+Its possible that you want the JS to be bundled into the storybook app, so you can use it without having the packager server running. You can get this done by adding few configurations to the `android/app/build.gradle` file.
+
+```diff
++if (System.getenv('STORYBOOK_BUNDLE')){
++  project.ext.react = [
++    entryFile: "storybook/index.android.js",
++    bundleInStorybook: true
++  ]
++}
+
+apply from: "../../node_modules/react-native/react.gradle"
+```
+
+Its important that these are added before `apply from: "../../node_modules/react-native/react.gradle"`.
+
+Now when you start the storybook app with `npm run storybook-android` if you have an environment variable `STORYBOOK_BUNDLE` available the JS will be bundled into the app. If you want this run,
+
+`STORYBOOK_BUNDLE=1 npm run storybook-android`


### PR DESCRIPTION
By those instructions the JS sources will be bundled and available in the app instead of fetching from packager.
