### PR TITLE
Support older react-native versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "homepage": "https://github.com/kadirahq/react-native-storybook#readme",
   "peerDependencies": {
-    "react": "^15.2.0",
-    "react-native": "^0.31.0"
+    "react": "^15.1.0",
+    "react-native": "0.27.0 - 0.31.x"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
Increase the version range in package.json file to support older react-native versions. Tested this on an older RN app and it's working fine. I think we did something wrong last time we tried `--root, --projectRoot` approach.
