### PR TITLE
Screenshot preview in browser

### DIFF
--- a/src/manager/components/StorySnapshotView/index.js
+++ b/src/manager/components/StorySnapshotView/index.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+
+const style = {
+  maxHeight: '100%',
+  marginLeft: 'auto',
+  marginRight: 'auto',
+  display: 'block'
+}
+
+export default class StorySnapshotView extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { uri: null }
+    this.channel = null;
+  }
+
+  componentWillMount() {
+    const { channel } = this.props;
+    if (channel) {
+      this.channel = channel;
+      channel.on('snapshotTaken', ({ uri }) => {
+        var relativeFilePath = uri.match(/\/Devices\/(.*)/)[1];
+        this.setState({uri: '/screenshot/' + relativeFilePath});
+      });
+    }
+  }
+
+  render() {
+    const { uri } = this.state;
+    return uri ? <img src={uri} style={style} /> : null;
+  }
+}

--- a/src/manager/provider.js
+++ b/src/manager/provider.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Provider } from '@kadira/storybook-ui';
 import createChannel from '@kadira/storybook-channel-websocket';
 import addons from '@kadira/storybook-addons';
+import StorySnapshotView from './components/StorySnapshotView';
 
 export default class ReactProvider extends Provider {
   constructor({ url }) {
@@ -21,7 +22,7 @@ export default class ReactProvider extends Provider {
   renderPreview(kind, story) {
     this.selection = { kind, story };
     this.channel.emit('setCurrentStory', { kind, story });
-    return null;
+    return <StorySnapshotView channel={this.channel} />;
   }
 
   handleAPI(api) {

--- a/src/preview/components/StoryView/index.js
+++ b/src/preview/components/StoryView/index.js
@@ -1,10 +1,25 @@
 import React, { Component } from 'react';
+import { UIManager } from 'react-native';
 
 export default class StoryView extends Component {
   constructor(props, ...args) {
     super(props, ...args);
     this.state = {storyFn: null};
-    this.props.events.on('story', storyFn => this.setState({storyFn}));
+    this.props.events.on('story', storyFn => {
+      this.setState({storyFn},() => this._takeSnapshot.call(this));
+    });
+  }
+
+  _takeSnapshot() {
+    const { channel } = this.props;
+    if (channel) {
+      requestAnimationFrame(() => {
+        UIManager
+          .takeSnapshot('window', {format: 'jpeg', quality: 0.8})
+          .then((uri) => channel.emit('snapshotTaken', {uri}))
+          .catch((error) => alert(error));
+      })
+    }
   }
 
   render() {

--- a/src/preview/index.js
+++ b/src/preview/index.js
@@ -67,7 +67,7 @@ export default class Preview {
       this._sendSetStories();
       this._sendGetCurrentStory();
       // finally return the preview component
-      return <StoryView events={this._events} />;
+      return <StoryView events={this._events} channel={channel} />;
     }
   }
 

--- a/src/server/middleware.js
+++ b/src/server/middleware.js
@@ -1,4 +1,6 @@
-import { Router } from 'express';
+import express, { Router } from 'express';
+import path from 'path';
+import process from 'process';
 import webpack from 'webpack';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
@@ -27,6 +29,15 @@ export default function (configDir) {
   const router = new Router();
   router.use(webpackDevMiddleware(compiler, devMiddlewareOptions));
   router.use(webpackHotMiddleware(compiler));
+
+  function resolvePath(str) {
+    if (str.substr(0, 2) === '~/') {
+      str = (process.env.HOME || process.env.HOMEPATH || process.env.HOMEDIR || process.cwd()) + str.substr(1);
+    }
+    return path.resolve(str);
+  }
+
+  router.use('/screenshot', express.static(resolvePath('~/Library/Developer/CoreSimulator/Devices')))
 
   router.get('/', function (req, res) {
     res.send(getIndexHtml(publicPath));


### PR DESCRIPTION
An early attempt to make the story screenshot displayed inside browser panel. 

Some known issues:
-  `UImanager.takeSnapshot` is only available in iOS.
- Screenshot files is stored at simulator tmp folder,  need some mechanism to delete old ones. 
- Hot reload of RN won't trigger any updates on screenshot preview.

Preview:
![screen shot 2016-08-26 at 10 58 48](https://cloud.githubusercontent.com/assets/839973/18009893/b8a9661c-6be0-11e6-8988-6d5fd4ddde60.png)
