### PR TITLE
Use new addon API to get preview component

### DIFF
--- a/dist/manager/provider.js
+++ b/dist/manager/provider.js
@@ -68,6 +68,10 @@ var ReactProvider = function (_Provider) {
     value: function renderPreview(kind, story) {
       this.selection = { kind: kind, story: story };
       this.channel.emit('setCurrentStory', { kind: kind, story: story });
+      var renderPreview = _storybookAddons2.default.getPreview();
+      if (renderPreview) {
+        return renderPreview(kind, story);
+      }
       return null;
     }
   }, {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@kadira/storybook-addon-actions": "^1.0.4",
     "@kadira/storybook-addon-links": "^1.0.1",
-    "@kadira/storybook-addons": "^1.3.1",
+    "@kadira/storybook-addons": "^1.4.0",
     "@kadira/storybook-channel-websocket": "^1.0.1",
     "@kadira/storybook-ui": "^3.3.1",
     "autoprefixer": "^6.4.0",

--- a/src/manager/provider.js
+++ b/src/manager/provider.js
@@ -21,6 +21,10 @@ export default class ReactProvider extends Provider {
   renderPreview(kind, story) {
     this.selection = { kind, story };
     this.channel.emit('setCurrentStory', { kind, story });
+    const renderPreview = addons.getPreview();
+    if (renderPreview) {
+      return renderPreview(kind, story);
+    }
     return null;
   }
 


### PR DESCRIPTION
The Storybook addon API supports custom preview functions from `v1.4.0`. Use it so developers can set custom preview panels using addons.
