### PR TITLE
Enable greenkeeper

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "prepublish": ".scripts/npm-prepublish.sh",
-    "test": "mocha -r babel-register -r babel-polyfill src/**/__tests__/**/*.js"
+    "test": "mocha -r babel-register -r babel-polyfill src/**/__tests__/**/*.js",
+    "postpublish": "greenkeeper-postpublish"
   },
   "repository": {
     "type": "git",
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
+    "greenkeeper-postpublish": "^1.0.1",
     "react": "^15.2.0",
     "react-native": "^0.32.0"
   },


### PR DESCRIPTION
Scoped modules need a postpublish hook to enable greenkeeper.io
