### PR TITLE
Add option to use storybook with more than one user

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "shelljs": "^0.7.3",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
+    "uuid": "^3.0.1",
     "webpack": "^1.13.2",
     "webpack-dev-middleware": "^1.8.3",
     "webpack-hot-middleware": "^2.12.2"

--- a/src/bin/storybook-start.js
+++ b/src/bin/storybook-start.js
@@ -8,9 +8,10 @@ import Server from '../server';
 program
   .option('-h, --host <host>', 'host to listen on')
   .option('-p, --port <port>', 'port to listen on')
+  .option('-s, --secured', 'whether server is running on https')
   .option('-c, --config-dir [dir-name]', 'storybook config directory')
   .option('-r, --reset-cache', 'reset react native packager')
-  .option('-s, --skip-packager', 'run only storybook server')
+  .option('--skip-packager', 'run only storybook server')
   .option('-i, --manual-id', 'allow multiple users to work with same storybook')
   .parse(process.argv);
 
@@ -21,7 +22,7 @@ if (program.host) {
   listenAddr.push(program.host);
 }
 
-const server = new Server({projectDir, configDir, manualId: program.manualId});
+const server = new Server({projectDir, configDir, manualId: program.manualId, secured: props.secured});
 server.listen(...listenAddr, function (err) {
   if (err) {
     throw err;

--- a/src/bin/storybook-start.js
+++ b/src/bin/storybook-start.js
@@ -10,6 +10,7 @@ program
   .option('-p, --port <port>', 'port to listen on')
   .option('-s, --secured', 'whether server is running on https')
   .option('-c, --config-dir [dir-name]', 'storybook config directory')
+  .option('-e, --environment [environment]', 'DEVELOPMENT/PRODUCTION environment for webpack')
   .option('-r, --reset-cache', 'reset react native packager')
   .option('--skip-packager', 'run only storybook server')
   .option('-i, --manual-id', 'allow multiple users to work with same storybook')
@@ -22,7 +23,14 @@ if (program.host) {
   listenAddr.push(program.host);
 }
 
-const server = new Server({projectDir, configDir, manualId: program.manualId, secured: program.secured});
+const server = new Server({
+  projectDir,
+  configDir,
+  environment: program.environment,
+  manualId: program.manualId,
+  secured: program.secured
+});
+
 server.listen(...listenAddr, function (err) {
   if (err) {
     throw err;

--- a/src/bin/storybook-start.js
+++ b/src/bin/storybook-start.js
@@ -9,6 +9,9 @@ program
   .option('-h, --host <host>', 'host to listen on')
   .option('-p, --port <port>', 'port to listen on')
   .option('-c, --config-dir [dir-name]', 'storybook config directory')
+  .option('-r, --reset-cache', 'reset react native packager')
+  .option('-s, --skip-packager', 'run only storybook server')
+  .option('-i, --manual-id', 'allow multiple users to work with same storybook')
   .parse(process.argv);
 
 const projectDir = path.resolve();
@@ -18,7 +21,7 @@ if (program.host) {
   listenAddr.push(program.host);
 }
 
-const server = new Server({projectDir, configDir});
+const server = new Server({projectDir, configDir, manualId: program.manualId});
 server.listen(...listenAddr, function (err) {
   if (err) {
     throw err;
@@ -27,11 +30,15 @@ server.listen(...listenAddr, function (err) {
   console.info(`\nReact Native Storybook started on => ${address}\n`);
 });
 
-const projectRoots = configDir === projectDir ? [configDir] : [configDir, projectDir];
+if (!program.skipPackager) {
+  const projectRoots = configDir === projectDir ? [configDir] : [configDir, projectDir];
 
 // RN packager
-shelljs.exec([
-  'node node_modules/react-native/local-cli/cli.js start',
-  `--projectRoots ${projectRoots.join(',')}`,
-  `--root ${projectDir}`,
-].join(' '), {async: true});
+  shelljs.exec([
+    'node node_modules/react-native/local-cli/cli.js start',
+    `--projectRoots ${projectRoots.join(',')}`,
+    `--root ${projectDir}`,
+    program.resetCache && '--reset-cache'
+  ].filter(x => x).join(' '), {async: true});
+
+}

--- a/src/bin/storybook-start.js
+++ b/src/bin/storybook-start.js
@@ -22,7 +22,7 @@ if (program.host) {
   listenAddr.push(program.host);
 }
 
-const server = new Server({projectDir, configDir, manualId: program.manualId, secured: props.secured});
+const server = new Server({projectDir, configDir, manualId: program.manualId, secured: program.secured});
 server.listen(...listenAddr, function (err) {
   if (err) {
     throw err;

--- a/src/manager/index.js
+++ b/src/manager/index.js
@@ -2,4 +2,4 @@ import renderStorybookUI from '@kadira/storybook-ui';
 import Provider from './provider';
 
 const rootEl = document.getElementById('root');
-renderStorybookUI(rootEl, new Provider({ url: `ws://${location.host}`, options: window.storybookOptions}));
+renderStorybookUI(rootEl, new Provider({ url: location.host, options: window.storybookOptions}));

--- a/src/manager/index.js
+++ b/src/manager/index.js
@@ -2,4 +2,4 @@ import renderStorybookUI from '@kadira/storybook-ui';
 import Provider from './provider';
 
 const rootEl = document.getElementById('root');
-renderStorybookUI(rootEl, new Provider({ url: `ws://${location.host}` }));
+renderStorybookUI(rootEl, new Provider({ url: `ws://${location.host}`, options: window.storybookOptions}));

--- a/src/manager/provider.js
+++ b/src/manager/provider.js
@@ -2,12 +2,23 @@ import React from 'react';
 import { Provider } from '@kadira/storybook-ui';
 import createChannel from '@kadira/storybook-channel-websocket';
 import addons from '@kadira/storybook-addons';
+import uuid from 'uuid';
 
 export default class ReactProvider extends Provider {
-  constructor({ url }) {
+  constructor({ url: domain, options }) {
     super();
+    this.options = options;
     this.selection = null;
     this.channel = addons.getChannel();
+
+    let url = domain;
+    if (options.manualId) {
+      const pairedId = uuid().substr(-6);
+
+      this.pairedId = pairedId;
+      url = domain + '/pairedId=' + this.pairedId;
+    }
+
     if (!this.channel) {
       this.channel = createChannel({ url });
       addons.setChannel(this.channel);
@@ -22,10 +33,19 @@ export default class ReactProvider extends Provider {
     this.selection = { kind, story };
     this.channel.emit('setCurrentStory', { kind, story });
     const renderPreview = addons.getPreview();
-    if (renderPreview) {
-      return renderPreview(kind, story);
+
+    const innerPreview = renderPreview ? renderPreview(kind, story) :  null;
+
+    if (this.options.manualId) {
+      return (
+        <div>
+          Your ID: { this.pairedId }
+          { innerPreview }
+        </div>
+      );
     }
-    return null;
+
+    return innerPreview;
   }
 
   handleAPI(api) {

--- a/src/manager/provider.js
+++ b/src/manager/provider.js
@@ -11,12 +11,14 @@ export default class ReactProvider extends Provider {
     this.selection = null;
     this.channel = addons.getChannel();
 
-    let url = domain;
+    const secured = options.secured;
+    const websocketType = secured ? 'wss' : 'ws';
+    let url = websocketType + '://' + domain;
     if (options.manualId) {
       const pairedId = uuid().substr(-6);
 
       this.pairedId = pairedId;
-      url = domain + '/pairedId=' + this.pairedId;
+      url += '/pairedId=' + this.pairedId;
     }
 
     if (!this.channel) {

--- a/src/preview/components/StoryView/index.js
+++ b/src/preview/components/StoryView/index.js
@@ -6,7 +6,14 @@ export default class StoryView extends Component {
   constructor(props, ...args) {
     super(props, ...args);
     this.state = {storyFn: null, selection: {}};
-    this.props.events.on('story', this.selectStory.bind(this));
+
+    this.storyHandler = this.selectStory.bind(this);
+
+    this.props.events.on('story', this.storyHandler);
+  }
+
+  componentWillUnmount() {
+    this.props.events.removeListener('story', this.storyHandler);
   }
 
   selectStory(storyFn, selection) {

--- a/src/preview/index.js
+++ b/src/preview/index.js
@@ -58,13 +58,18 @@ export default class Preview {
       let channel = addons.getChannel();
       if (params.resetStorybook || !channel) {
         const host = params.host || 'localhost';
-        const port = params.port || 7007;
+
+        const port = params.port !== false
+          ? ':' + (params.port || 7007)
+          : '';
+
         const query = params.query || '';
         const secured = params.secured;
-        const websocketType = secured ?  'wss' : 'ws';
+        const websocketType = secured ? 'wss' : 'ws';
         const httpType = secured ? 'https' : 'http';
-        const url = `${websocketType}://${host}:${port}/${query}`;
-        webUrl = `${httpType}://${host}:${port}`;
+
+        const url = `${websocketType}://${host}${port}/${query}`;
+        webUrl = `${httpType}://${host}${port}`;
         channel = createChannel({ url });
         addons.setChannel(channel);
       }

--- a/src/preview/index.js
+++ b/src/preview/index.js
@@ -60,8 +60,11 @@ export default class Preview {
         const host = params.host || 'localhost';
         const port = params.port || 7007;
         const query = params.query || '';
-        const url = `ws://${host}:${port}/${query}`;
-        webUrl = `http://${host}:${port}`;
+        const secured = params.secured;
+        const websocketType = secured ?  'wss' : 'ws';
+        const httpType = secured ? 'https' : 'http';
+        const url = `${websocketType}://${host}:${port}/${query}`;
+        webUrl = `${httpType}://${host}:${port}`;
         channel = createChannel({ url });
         addons.setChannel(channel);
       }

--- a/src/preview/index.js
+++ b/src/preview/index.js
@@ -56,10 +56,10 @@ export default class Preview {
     return () => {
       let webUrl = null;
       let channel = addons.getChannel();
-      if (!channel) {
+      if (params.resetStorybook || !channel) {
         const host = params.host || 'localhost';
         const port = params.port || 7007;
-        const url = `ws://${host}:${port}`;
+        const url = `ws://${host}:${port}/${params.query}`;
         webUrl = `http://${host}:${port}`;
         channel = createChannel({ url });
         addons.setChannel(channel);

--- a/src/preview/index.js
+++ b/src/preview/index.js
@@ -59,7 +59,8 @@ export default class Preview {
       if (params.resetStorybook || !channel) {
         const host = params.host || 'localhost';
         const port = params.port || 7007;
-        const url = `ws://${host}:${port}/${params.query}`;
+        const query = params.query || '';
+        const url = `ws://${host}:${port}/${query}`;
         webUrl = `http://${host}:${port}`;
         channel = createChannel({ url });
         addons.setChannel(channel);

--- a/src/server/config/webpack.config.prod.js
+++ b/src/server/config/webpack.config.prod.js
@@ -14,13 +14,14 @@ const config = {
   devtool: '#cheap-module-source-map',
   entry: entries,
   output: {
+    path: path.join(__dirname, 'dist'),
     filename: 'static/[name].bundle.js',
     // Here we set the publicPath to ''.
     // This allows us to deploy storybook into subpaths like GitHub pages.
     // This works with css and image loaders too.
     // This is working for storybook since, we don't use pushState urls and
     // relative URLs works always.
-    publicPath: '',
+    publicPath: '/',
   },
   plugins: [
     new webpack.DefinePlugin({ 'process.env.NODE_ENV': '"production"' }),

--- a/src/server/index.html.js
+++ b/src/server/index.html.js
@@ -1,6 +1,6 @@
 import url from 'url';
 
-export default function (publicPath, settings) {
+export default function (publicPath, options) {
   return `
     <!DOCTYPE html>
     <html>
@@ -40,6 +40,9 @@ export default function (publicPath, settings) {
       </head>
       <body style="margin: 0;">
         <div id="root"></div>
+        <script>
+          window.storybookOptions = ${JSON.stringify(options)};
+        </script>
         <script src="${url.resolve(publicPath, 'static/manager.bundle.js')}"></script>
       </body>
     </html>

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import querystring from 'querystring';
 import http from 'http';
 import ws from 'ws';
 import storybook from './middleware';
@@ -8,15 +9,30 @@ export default class Server {
     this.options = options;
     this.httpServer = http.createServer();
     this.expressApp = express();
-    this.expressApp.use(storybook(options.projectDir, options.configDir));
+    this.expressApp.use(storybook(options));
     this.httpServer.on('request', this.expressApp);
     this.wsServer = ws.Server({server: this.httpServer});
     this.wsServer.on('connection', s => this.handleWS(s));
   }
 
   handleWS(socket) {
+
+    if (this.options.manualId) {
+      const params = socket.upgradeReq && socket.upgradeReq.url
+        ? querystring.parse(socket.upgradeReq.url.substr(1))
+        : {};
+
+      if (params.pairedId) {
+        socket.pairedId = params.pairedId;
+      }
+    }
+
     socket.on('message', data => {
-      this.wsServer.clients.forEach(c => c.send(data));
+      this.wsServer.clients.forEach(c => {
+        if (!this.options.manualId || (socket.pairedId && socket.pairedId === c.pairedId)) {
+          return c.send(data);
+        }
+      });
     });
   }
 

--- a/src/server/middleware.js
+++ b/src/server/middleware.js
@@ -5,6 +5,7 @@ import webpack from 'webpack';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
 import baseConfig from './config/webpack.config';
+import baseProductionConfig from './config/webpack.config.prod';
 import loadConfig from './config';
 import getIndexHtml from './index.html';
 
@@ -23,7 +24,9 @@ function getMiddleware(configDir) {
 export default function ({projectDir, configDir, ...options}) {
   // Build the webpack configuration using the `baseConfig`
   // custom `.babelrc` file and `webpack.config.js` files
-  const config = loadConfig('DEVELOPMENT', baseConfig, projectDir, configDir);
+  const environment = options.environment || 'DEVELOPMENT';
+  const currentWebpackConfig = environment === 'PRODUCTION' ? baseProductionConfig : baseConfig;
+  const config = loadConfig(environment, currentWebpackConfig, projectDir, configDir);
 
   // remove the leading '/'
   let publicPath = config.output.publicPath;

--- a/src/server/middleware.js
+++ b/src/server/middleware.js
@@ -25,7 +25,8 @@ export default function ({projectDir, configDir, ...options}) {
   // Build the webpack configuration using the `baseConfig`
   // custom `.babelrc` file and `webpack.config.js` files
   const environment = options.environment || 'DEVELOPMENT';
-  const currentWebpackConfig = environment === 'PRODUCTION' ? baseProductionConfig : baseConfig;
+  const isProd = environment === 'PRODUCTION';
+  const currentWebpackConfig = isProd ? baseProductionConfig : baseConfig;
   const config = loadConfig(environment, currentWebpackConfig, projectDir, configDir);
 
   // remove the leading '/'
@@ -46,7 +47,10 @@ export default function ({projectDir, configDir, ...options}) {
   middlewareFn(router);
 
   router.use(webpackDevMiddleware(compiler, devMiddlewareOptions));
-  router.use(webpackHotMiddleware(compiler));
+
+  if (!isProd) {
+    router.use(webpackHotMiddleware(compiler));
+  }
 
   router.get('/', function (req, res) {
     res.send(getIndexHtml(publicPath, {

--- a/src/server/middleware.js
+++ b/src/server/middleware.js
@@ -48,6 +48,7 @@ export default function ({projectDir, configDir, ...options}) {
   router.get('/', function (req, res) {
     res.send(getIndexHtml(publicPath, {
       manualId: options.manualId,
+      secured: options.secured,
     }));
   });
 

--- a/src/server/middleware.js
+++ b/src/server/middleware.js
@@ -20,7 +20,7 @@ function getMiddleware(configDir) {
   return function () {};
 }
 
-export default function (projectDir, configDir) {
+export default function ({projectDir, configDir, ...options}) {
   // Build the webpack configuration using the `baseConfig`
   // custom `.babelrc` file and `webpack.config.js` files
   const config = loadConfig('DEVELOPMENT', baseConfig, projectDir, configDir);
@@ -46,7 +46,9 @@ export default function (projectDir, configDir) {
   router.use(webpackHotMiddleware(compiler));
 
   router.get('/', function (req, res) {
-    res.send(getIndexHtml(publicPath));
+    res.send(getIndexHtml(publicPath, {
+      manualId: options.manualId,
+    }));
   });
 
   return router;


### PR DESCRIPTION
# Add option to differentiate connected users
We really like what storybook has to offer. We are going to use it to host our styleguide examples. We didn't like option to use react native web, we wanted users to be able to feel components in their phone. But react-native-stylebook doesn't support more than one user at the time. That is why I added options necessary to be able to host react-native-storybook in server and allow users play with the components.

[wix/react-native-storybook-example](https://github.com/wix/react-native-storybook-example)

Some work in progress, but in this gif you can see that we have one styleguide server running, two simulators and two browsers. User enters the code he sees (later on it could be QR code or anything else) and then he can play with his app without interupting others.

![Two simulators, two browsers one server playing together](https://media.giphy.com/media/3oKIPhYRUyUO5I6pWw/giphy.gif)


## I've added some command parameters:
* --reset-cache (simply passes option to react-native cli, when developing it sometimes makes difficult hard to debug, because it likes to cache things).
* --skip-packager (skip react-native packager all together and start only storybook server).
* --manual-id (tells storybook that now users should get custom id which they have to use in react-native app to connect to storybook. It allows to deploy storybook server to any host and tell users to download the app and enter code to play with it. If this flag is not passed, everything works same way as before. When user opens storybook he gets his own custom id and that id is sent through websocket query to be saved in server.).
* --secured (Tells to use https/wss instead of http/ws).
* --environment DEVELOPMENT/PRODUCTION (Which webpack config to use, production one disables hot reload/enables code minification).

## Also one bug fixed:
Story view component unmounts its events listeners when it is not rendered anymore.

Sadly I had to insert one dependency (uuid). It was already a dependency of some other your used package. In my opinion it is not that bad, because this id thing could be a core feature of react-native-storybook.

## How things work:
If you don't use --manual-id option, everything works same way as before.
When you apply --manual-id option when running script, every time someone opens a storybook they will get uniq Id (it is random, so there is a chance of collision, but it shouldn't be a problem).
That uniqId is sent through websocket query to server (ws://localhost:7007/pairedId=1234).
When any event happens and a new data is being sent through websocket data will be only sent to other browsers/phones who also have pairedId=1234.

I have also added example screen to enter code in react-native in example project. Same thing happens in phone, you enter code, it is set through query. If you want to look into things more closely, there is a readme file inside example project. Also it is not very big, so it shouldn't take long time to look into contents inside it.
 