### PR TITLE
Extend supported react-native range to v0.43

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
   "homepage": "https://github.com/kadirahq/react-native-storybook#readme",
   "peerDependencies": {
     "react": "^15.3.2",
-    "react-native": "0.27.0 - 0.42.x"
+    "react-native": "0.27.0 - 0.43.x"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
     "greenkeeper-postpublish": "^1.0.1",
     "react": "^15.2.0",
-    "react-native": "^0.39.0"
+    "react-native": "^0.43.0"
   },
   "dependencies": {
     "@kadira/storybook-addon-actions": "^1.0.4",


### PR DESCRIPTION
It's weird that react-native has an alpha version of React as peer dependency [here](https://github.com/facebook/react-native/blob/11f16ebdbb83d770e0c6bbebb306282914758bd0/package.json#L129,L131). Should decide whether we should also use the alpha version or wait until a more stable version comes out.